### PR TITLE
Creates profiles markup generator, cleans up contact null cases, removes cta buttons

### DIFF
--- a/features/contact_info.js
+++ b/features/contact_info.js
@@ -5,34 +5,50 @@ const { BotkitConversation } = require('botkit');
 const resume = require("../public/assets/resume.json");
 
 module.exports = function (controller) {
-  //Answers to questions related to contact information
+  //Generates an array of objects with answers to profile questions
+  const allProfiles = resume.basics.profiles.map(profile => {
+    return {
+      'network': profile.network,
+      'listItem': `<li>${profile.network}: <a href = ${profile.url} target = "_blank" >${profile.network}</a></li>`,
+      'hyperlink': `<a href = ${profile.url} target = "_blank" >${profile.network}</a>`
+    };
+  });
+  //Generate a bot listener for each contact network profile
+  allProfiles.forEach(profile => {
+    const query = profile.network.toLowerCase();
+    return controller.hears(new RegExp(query, 'i'), ['message'], async (bot, message) => {
+      await bot.reply(message, `Connect with ${firstName} on ${profile.hyperlink}`);
+    });
+  });
+  //Generates quick replies for network profiles
+  const profileQuickReplies = allProfiles.map(profile => {
+    return { 'title': profile.network, 'payload': profile.network.toLowerCase() };
+  });
+
+  //Answers to questions related to basic contact information
   const firstName = resume.basics.name.split(' ')[0];
-  const contactPhone = `<a href="tel:+1${resume.basics.phone}">${resume.basics.phone}</a>`;
-  const contactEmail = `<a href="mailto:${resume.basics.email}" target="_blank">${resume.basics.email}</a>`;
-  const contactLinkedIn = `<a href="${resume.basics.profiles.filter(profile => profile.network === "LinkedIn")[0].url}" target="_blank">LinkedIn</a>`;
-  const contactGithub = `<a href="${resume.basics.profiles.filter(profile => profile.network === "Github")[0].url}" target="_blank">Github</a>`;
-  const contactAddress = `${resume.basics.location.city}, ${resume.basics.location.region}, ${resume.basics.location.countryCode}`;
+  const contactAllProfiles = allProfiles.length > 0 ? allProfiles.map(profile => profile.listItem).join('') : null;
+  const contactPhone = resume.basics.phone !== '' ? `<a href="tel:+1${resume.basics.phone}">${resume.basics.phone}</a>` : null;
+  const contactEmail = resume.basics.email !== '' ? `<a href="mailto:${resume.basics.email}" target="_blank">${resume.basics.email}</a>` : null;
+  const contactCity = resume.basics.location.city ? `${resume.basics.location.city}, `: '';
+  const contactRegion = resume.basics.location.region ? `${resume.basics.location.region}, ` : '';
+  const contactCountry = resume.basics.location.countryCode ? `${resume.basics.location.countryCode}` : '';
+  const contactAddress = `${contactCity}${contactRegion}${contactCountry}`;
   const contactSummary = `${resume.basics.summary}`;
 
   //Bot listeners
   controller.hears('all contact info', ['message'], async (bot, message) => {
-    await bot.reply(message, `<p>Here are a few places where you can reach ${firstName}:</p><ul><li>Phone: ${contactPhone}</li><li>Email: ${contactEmail}</li><li>LinkedIn: ${contactLinkedIn}</li><li>Github: ${contactGithub}</li><li>Location: ${contactAddress}</li></ul><p>Hope you have a spooky good time connecting!</p>`);
+    await bot.reply(message, `<p>Here are a few places where you can reach ${firstName}:</p><ul>${contactPhone ? `<li>Phone: ${contactPhone}</li>` : ''}<li>Email: ${contactEmail}</li>${contactAllProfiles ? contactAllProfiles : ''}${contactAddress !== '' ? `<li>Location: ${contactAddress} </li>` : ''}</ul><p>Hope you have a spooky good time connecting!</p>`);
     await bot.cancelAllDialogs();
   });
   controller.hears(new RegExp(/phone|call/i), ['message'], async (bot, message) => {
-    await bot.reply(message, `Call or text ${firstName} at ${contactPhone}`);
+    await bot.reply(message, contactPhone ? `Call or text ${firstName} at ${contactPhone}` : `Sorry ${firstName} does not share their phone number.`);
   });
   controller.hears(new RegExp(/email/i), ['message'], async (bot, message) => {
-    await bot.reply(message, `Email ${firstName} at ${contactEmail}`);
-  });
-  controller.hears(new RegExp(/git/i), ['message'], async (bot, message) => {
-    await bot.reply(message, `Check out ${firstName}\'s projects on ${contactGithub}`);
-  });
-  controller.hears(new RegExp(/linkedin/i), ['message'], async (bot, message) => {
-    await bot.reply(message, `Connect with ${firstName} on ${contactLinkedIn}`);
+    await bot.reply(message, contactEmail ? `Email ${firstName} at ${contactEmail}` : `Sorry ${firstName} does not share their email.`);
   });
   controller.hears(new RegExp(/address|live/i), ['message'], async (bot, message) => {
-    await bot.reply(message, `${firstName} lives in ${contactAddress}. Trick or Treat!`);
+    await bot.reply(message, contactAddress ? `${firstName} lives in ${contactAddress}. Trick or Treat!` : `Sorry ${firstName} does not share their address.`);
   });
   controller.hears(new RegExp('summary'), ['message'], async (bot, message) => {
     await bot.reply(message, `Certainly! Here\'s what ${firstName} has to say`);
@@ -47,9 +63,9 @@ module.exports = function (controller) {
     await bot.reply(message, contactSummary);
   });
 
+
   //Creates an instance of a conversation for dialog tree
   const contactInfo = new BotkitConversation('contactInfo', controller);
-
 
   // create a path for when a user says YES
   contactInfo.addMessage({
@@ -68,18 +84,10 @@ module.exports = function (controller) {
         payload: "email"
       },
       {
-        title: "Linkedin",
-        payload: "linkedin"
-      },
-      {
-        title: "Github",
-        payload: "github"
-      },
-      {
         title: "Address",
         payload: "address"
       },
-    ]
+    ].concat(profileQuickReplies)
   }, 'yes_thread');
 
   // create a path for when a user says NO

--- a/public/client.js
+++ b/public/client.js
@@ -353,27 +353,6 @@ var Botkit = {
 
         that.input = document.getElementById('messenger_input');
 
-        //Call to action buttons send a message by default on behalf of the user
-        that.contactCallToAction = document.getElementById('call_to_action_contact');
-        that.contactCallToAction.addEventListener('click', function () {
-            that.send('contact');
-        });
-
-        that.contactCallToAction = document.getElementById('call_to_action_education');
-        that.contactCallToAction.addEventListener('click', function () {
-            that.send('education');
-        });
-
-        that.contactCallToAction = document.getElementById('call_to_action_work');
-        that.contactCallToAction.addEventListener('click', function () {
-            that.send('work');
-        });
-
-        that.contactCallToAction = document.getElementById('call_to_action_skills');
-        that.contactCallToAction.addEventListener('click', function () {
-            that.send('tech stack');
-        });
-
         that.focus();
 
         that.on('connected', function () {
@@ -382,7 +361,7 @@ var Botkit = {
             that.sendEvent({
                 name: 'connected'
             });
-        })
+        });
 
         that.on('disconnected', function () {
             that.message_window.className = 'disconnected';

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -296,40 +296,6 @@ a.button:hover {
   box-shadow: 0 0 0 1pt blue; 
 }
 
-#call_to_action {
-  display: flex;
-  justify-content: center;
-}
-
-#call_to_action ul {
-  list-style-type: none;
-  margin: 0px auto;
-  padding: 0;
-}
-#call_to_action ul li {
-  display: inline-block;
-  margin: 0.5rem;
-  margin-left: 0;
-}
-#call_to_action button {
-  text-decoration: none;
-  display: block;
-  border: 1px solid #a795ef;
-  color: #a795ef;
-  border-radius: 16px;
-  padding: 0.25rem 1rem;
-  font-size: 14px;
-  cursor: pointer;
-  outline: none;
-}
-#call_to_action button:hover {
-  background: #a795ef;
-  color: #FFF;
-}
-#call_to_action button:focus {
-  box-shadow: 0 0 0 1pt blue; 
-}
-
 .work_history {
   padding-left: 0;
   color: #1a202c;

--- a/public/index.html
+++ b/public/index.html
@@ -52,14 +52,6 @@
                     <input type="text" autocomplete="off" id="messenger_input" placeholder="Send a spooky message..." />
                     <button id="send-button" type="submit">Send</button>
                 </form>
-                <div id="call_to_action">
-                  <ul>
-                    <li><button id="call_to_action_contact">Contact</button></li>
-                    <li><button id="call_to_action_education">Education</button></li>
-                    <li><button id="call_to_action_work">Work</button></li>
-                    <li><button id="call_to_action_skills">Skills</button></li>
-                  </ul>
-                </div>
             </footer>
         </div>
         <img src="assets/ezgif.com-gif-maker.gif" />


### PR DESCRIPTION
### Summary
Previously, markup and bot listeners were created manually for each network profile. Now, markup and bot listeners are created dynamically  for each network profile, ensuring that no matter which networks are used by an individual, they should be usable in the bot.

Additionally, changes were made to the contact info to account for null data cases especially as it relates to phone and address which are pieces of data that many users may be unwilling to share in their resumes. 

Lastly, this PR removes the call to action buttons that used to persist just above the chat input field. These buttons are no longer necessary because we now include them in the welcome message.