### PR TITLE
Adds quick replies for work history, adds typing indicator in contact

### DIFF
--- a/features/contact_info.js
+++ b/features/contact_info.js
@@ -17,7 +17,12 @@ module.exports = function (controller) {
   allProfiles.forEach(profile => {
     const query = profile.network.toLowerCase();
     return controller.hears(new RegExp(query, 'i'), ['message'], async (bot, message) => {
-      await bot.reply(message, `Connect with ${firstName} on ${profile.hyperlink}`);
+      await bot.reply(message, { type: 'typing' });
+      setTimeout(async () => {
+        // will have to reset context because turn has now ended.
+        await bot.changeContext(message.reference);
+        await bot.reply(message, `Connect with ${firstName} on ${profile.hyperlink}`);
+      }, 1000);
     });
   });
   //Generates quick replies for network profiles
@@ -38,29 +43,63 @@ module.exports = function (controller) {
 
   //Bot listeners
   controller.hears('all contact info', ['message'], async (bot, message) => {
-    await bot.reply(message, `<p>Here are a few places where you can reach ${firstName}:</p><ul>${contactPhone ? `<li>Phone: ${contactPhone}</li>` : ''}<li>Email: ${contactEmail}</li>${contactAllProfiles ? contactAllProfiles : ''}${contactAddress !== '' ? `<li>Location: ${contactAddress} </li>` : ''}</ul><p>Hope you have a spooky good time connecting!</p>`);
-    await bot.cancelAllDialogs();
+    await bot.reply(message, { type: 'typing' });
+    setTimeout(async () => {
+      // will have to reset context because turn has now ended.
+      await bot.changeContext(message.reference);
+      await bot.reply(message, `<p>Here are a few places where you can reach ${firstName}:</p><ul>${contactPhone ? `<li>Phone: ${contactPhone}</li>` : ''}<li>Email: ${contactEmail}</li>${contactAllProfiles ? contactAllProfiles : ''}${contactAddress !== '' ? `<li>Location: ${contactAddress} </li>` : ''}</ul><p>Hope you have a spooky good time connecting!</p>`);
+    }, 1000);
   });
   controller.hears(new RegExp(/phone|call/i), ['message'], async (bot, message) => {
-    await bot.reply(message, contactPhone ? `Call or text ${firstName} at ${contactPhone}` : `Sorry ${firstName} does not share their phone number.`);
+    await bot.reply(message, { type: 'typing' });
+    setTimeout(async () => {
+      // will have to reset context because turn has now ended.
+      await bot.changeContext(message.reference);
+      await bot.reply(message, contactPhone ? `Call or text ${firstName} at ${contactPhone}` : `Sorry ${firstName} does not share their phone number.`);
+    }, 1000);
   });
   controller.hears(new RegExp(/email/i), ['message'], async (bot, message) => {
-    await bot.reply(message, contactEmail ? `Email ${firstName} at ${contactEmail}` : `Sorry ${firstName} does not share their email.`);
+    await bot.reply(message, { type: 'typing' });
+    setTimeout(async () => {
+      // will have to reset context because turn has now ended.
+      await bot.changeContext(message.reference);
+      await bot.reply(message, contactEmail ? `Email ${firstName} at ${contactEmail}` : `Sorry ${firstName} does not share their email.`);
+    }, 1000);
   });
   controller.hears(new RegExp(/address|live/i), ['message'], async (bot, message) => {
-    await bot.reply(message, contactAddress ? `${firstName} lives in ${contactAddress}. Trick or Treat!` : `Sorry ${firstName} does not share their address.`);
+    await bot.reply(message, { type: 'typing' });
+    setTimeout(async () => {
+      // will have to reset context because turn has now ended.
+      await bot.changeContext(message.reference);
+      await bot.reply(message, contactAddress ? `${firstName} lives in ${contactAddress}. Trick or Treat!` : `Sorry ${firstName} does not share their address.`);
+    }, 1000);
   });
   controller.hears(new RegExp('summary'), ['message'], async (bot, message) => {
     await bot.reply(message, `Certainly! Here\'s what ${firstName} has to say`);
-    await bot.reply(message, contactSummary);
+    await bot.reply(message, { type: 'typing' });
+    setTimeout(async () => {
+      // will have to reset context because turn has now ended.
+      await bot.changeContext(message.reference);
+      await bot.reply(message, contactSummary);
+    }, 1000);
   });
   controller.hears(new RegExp(`about ${firstName}`, 'i'), ['message'], async (bot, message) => {
     await bot.reply(message, `Certainly! Here\'s what ${firstName} has to say`);
-    await bot.reply(message, contactSummary);
+    await bot.reply(message, { type: 'typing' });
+    setTimeout(async () => {
+      // will have to reset context because turn has now ended.
+      await bot.changeContext(message.reference);
+      await bot.reply(message, contactSummary);
+    }, 1000);
   });
   controller.hears(new RegExp(`who is ${firstName}`, 'i'), ['message'], async (bot, message) => {
     await bot.reply(message, `Certainly! Here\'s what ${firstName} has to say`);
-    await bot.reply(message, contactSummary);
+    await bot.reply(message, { type: 'typing' });
+    setTimeout(async () => {
+      // will have to reset context because turn has now ended.
+      await bot.changeContext(message.reference);
+      await bot.reply(message, contactSummary);
+    }, 1000);
   });
 
 

--- a/features/interrupts.js
+++ b/features/interrupts.js
@@ -2,7 +2,7 @@ const resume = require("../public/assets/resume.json");
 
 module.exports = function (controller) {
 
-    controller.interrupts('help', 'message', async(bot, message) => {
+    controller.interrupts(/help|menu/i, 'message', async(bot, message) => {
         await bot.reply(
           message,
           "💀: Hey, no problem! Let me take you back to the beginning."

--- a/features/typing.js
+++ b/features/typing.js
@@ -8,7 +8,6 @@ module.exports = function(controller) {
 
     let typing = new BotkitConversation('typing', controller);
 
-    typing.say('I am going to type for a while now...');
     typing.addAction('typing');
 
     // start the typing indicator

--- a/features/work_history.js
+++ b/features/work_history.js
@@ -6,20 +6,41 @@ const { BotkitConversation } = require('botkit');
 const resume = require("../public/assets/resume.json");
 
 module.exports = function (controller) {
-  //Reusable work history variables
   const firstName = resume.basics.name.split(' ')[0];
-  const work = resume.work;
-  const workMarkup = work.map(job => {
+  //Generates an array of objects with helpful markup for each job
+  const allJobs = resume.work.map((job, idx) => {
     const formattedStart = formatDate(`${job.startDate}`, 'en-us', { month: 'short', year: 'numeric' });
     const formattedEnd = job.endDate === '' ? 'Present' : formatDate(`${job.endDate}`, 'en-us', { month: 'short', year: 'numeric' });
-    const highlights = job.highlights.map(highlight => `<li>${highlight}</li>`).join('');
-    
-    return `<li><div><div><h2>${job.position}</h2><span>${formattedStart} - ${formattedEnd}<span></div><h3>${job.name}</h3>${job.summary ? `<p>${job.summary}</p>` : ''}${highlights.length > 0 ? `<ul>${highlights}</ul>` : '' }</div></li>`;
-  }).join('');
+    const highlightsMarkup = `<ul>${job.highlights.map(highlight => `<li>${highlight}</li>`).join('')}</ul>`;
+
+    return {
+      'id': idx,
+      'name': job.name,
+      'position': job.position,
+      'startDate': job.startDate,
+      'endDate': job.endDate,
+      'markupLong': `<li><div><div><h2>${job.position}</h2><span>${formattedStart} - ${formattedEnd}<span></div><h3>${job.name}</h3>${job.summary ? `<p>${job.summary}</p>` : ''}${job.highlights.length > 0 ? highlightsMarkup : ''}</div></li>`,
+      'markupShort': `<p>${firstName} was a ${job.position} at ${job.name} from ${formattedStart} to ${formattedEnd}.</p>${job.summary ? `<p>${firstName} summarizes the experience as follows:</p><blockquote>${job.summary}</blockquote>` : ''}${job.highlights.length > 0 ? `<p>Here are a few highlights from ${firstName}\'s tenure:</p>${highlightsMarkup}` : ''}`,
+      'formattedStart': formattedStart,
+      'formattedEnd': formattedEnd,
+    };
+  });
+  //Generate a bot listener for each job company
+  allJobs.forEach(job => {
+    const position = job.position.toLowerCase();
+
+    return controller.hears(new RegExp(position, 'i'), ['message'], async (bot, message) => {
+      await bot.reply(message, job.markupShort);
+    });
+  });
+  //Generates quick replies for each job
+  const jobQuickReplies = allJobs.map(job => {
+    return { 'title': `${job.position} at ${job.name}`, 'payload': job.position.toLowerCase() };
+  });
 
   //Bot listeners
   controller.hears('all jobs info', ['message'], async (bot, message) => {
-    await bot.reply(message, `<ul class="work_history">${workMarkup}</ul>`);
+    await bot.reply(message, `<ul class="work_history">${allJobs.map(job => job.markupLong).join('')}</ul>`);
   });
 
   //Creates an instance of a conversation for dialog tree
@@ -27,7 +48,13 @@ module.exports = function (controller) {
 
   // create a path for when a user says YES
   workHistory.addMessage({
-    text: `<ul class="work_history">${workMarkup}</ul>`
+    text: 'Happy to help! Please select from one of these work history options:',
+    quick_replies: [
+      {
+        title: "All",
+        payload: "all jobs info",
+      },
+    ].concat(jobQuickReplies)
   }, 'yes_thread');
 
   // create a path for when a user says NO
@@ -76,7 +103,7 @@ module.exports = function (controller) {
   ], 'workHistory', 'default');
 
   controller.addDialog(workHistory);
-  controller.hears(new RegExp(/work|job/i), ['message', 'direct_message'], async (bot, message) => {
+  controller.hears(new RegExp(/work|job|resume|resumé|employer|employee/i), ['message', 'direct_message'], async (bot, message) => {
     await bot.beginDialog('workHistory');
   });
 };

--- a/public/assets/resume.json
+++ b/public/assets/resume.json
@@ -38,10 +38,10 @@
         {
             "name": "New York City Urban Debate League",
             "endDate": "2020-01-31",
-            "highlights": [],
+            "highlights": ["Improved overall stakeholder satisfaction by 23% by implementing new programming policies based on data collected from stakeholders","Oversaw a $1 million programming budget","Managed a team of four"],
             "position": "Program Manager",
             "startDate": "2017-09-30",
-            "summary": "-Improved overall stakeholder satisfaction by 23% by implementing new programming policies based on data collected from stakeholders\n\n-Oversaw a $1 million programming budget\n\n-Managed a team of four",
+            "summary": "Managed at team of debate coaches",
             "url": ""
         },
         {
@@ -50,7 +50,7 @@
             "highlights": [],
             "position": "Contributor",
             "startDate": "2017-04-30",
-            "summary": "- Wrote about tech, culture and their intersections",
+            "summary": "Wrote about tech, culture and their intersections",
             "url": ""
         },
         {
@@ -59,7 +59,7 @@
             "highlights": [],
             "position": "Writer",
             "startDate": "2017-02-28",
-            "summary": "- Covered culture, politics and breaking news",
+            "summary": "Covered culture, politics and breaking news",
             "url": ""
         },
         {
@@ -68,7 +68,7 @@
             "highlights": [],
             "position": "Contributor",
             "startDate": "2016-09-30",
-            "summary": "- Covered business, tech and politics",
+            "summary": "Covered business, tech and politics",
             "url": ""
         },
         {
@@ -77,7 +77,7 @@
             "highlights": [],
             "position": "Staff Writer",
             "startDate": "2014-07-31",
-            "summary": "- Covered breaking news and politics",
+            "summary": "Covered breaking news and politics",
             "url": ""
         }
     ],


### PR DESCRIPTION
### Summary
+ Work history now has functions that generate listeners and quick replies for each job
+ Typing indicators are now used for all reply messages in contact info
+ Small update to the resume so that highlights section on work history is more visible

### Notes
Quick replies and listeners are related to the job position. This could present issues for cases where a person has the same job at multiple companies, or the same job at the same company at different periods of time. These edge cases should be addressed in the future. 

To address the edge cases, I've added an id for each job profile object that should be able to identify uniqueness for jobs.